### PR TITLE
fix: resolve --file/THREADS_FILE paths against caller CWD; drop dead HEADER_MARKER

### DIFF
--- a/.mise/tasks/_resolve-file
+++ b/.mise/tasks/_resolve-file
@@ -11,10 +11,12 @@
 set -euo pipefail
 
 FILE="${1:-${THREADS_FILE:-}}"
+CALLER_DIR="${CALLER_PWD:-$(pwd)}"
 
 if [ -z "$FILE" ]; then
-  CALLER_DIR="${CALLER_PWD:-$(pwd)}"
   FILE="$CALLER_DIR/HUMAN.md"
+elif [ "${FILE#/}" = "$FILE" ]; then
+  FILE="$CALLER_DIR/$FILE"
 fi
 
 echo "$FILE"

--- a/.mise/tasks/archive
+++ b/.mise/tasks/archive
@@ -16,14 +16,13 @@ ARCHIVE_PATH="${THREADS_PATH%.md}.archive.md"
 HUMAN_PATH="$THREADS_PATH" ARCHIVE_PATH="$ARCHIVE_PATH" PYTHONPATH="$MISE_CONFIG_ROOT/lib" python3 << 'PYEOF'
 import os
 from datetime import date
-from human_threads import split_header_body, parse_threads
+from human_threads import parse_threads
 
 human_path = os.environ["HUMAN_PATH"]
 archive_path = os.environ["ARCHIVE_PATH"]
 
 content = open(human_path).read()
-header, body = split_header_body(content)
-preamble_lines, threads = parse_threads(body)
+preamble_lines, threads = parse_threads(content)
 
 kept = [(k, l) for k, l in threads if k != "success"]
 resolved = [(k, l) for k, l in threads if k == "success"]
@@ -53,7 +52,7 @@ for _kind, tlines in kept:
     new_body += "\n" + "\n".join(tlines) + "\n"
 
 with open(human_path, "w") as f:
-    f.write((header or "") + new_body)
+    f.write(new_body)
 
 s = "s" if len(resolved) != 1 else ""
 print(f"Archived {len(resolved)} resolved thread{s} to {os.path.basename(archive_path)}.")

--- a/.mise/tasks/fmt
+++ b/.mise/tasks/fmt
@@ -17,7 +17,7 @@ HUMAN_PATH="$THREADS_PATH" CHECK_MODE="$CHECK_MODE" PYTHONPATH="$MISE_CONFIG_ROO
 import re, os, sys
 from human_threads import (
     NAME_PAT, CALLOUT_OPENER,
-    split_header_body, parse_threads,
+    parse_threads,
     extract_thread_body, extract_message_senders, thread_waiting_on,
 )
 
@@ -71,8 +71,7 @@ if converted > 0:
 
 # --- Phase 2: Promote/demote thread callout types based on waiting-on ---
 
-header, body = split_header_body(content)
-preamble_lines, threads = parse_threads(body)
+preamble_lines, threads = parse_threads(content)
 
 if threads:
 
@@ -129,7 +128,7 @@ if threads:
     new_body = preamble + "\n"
     for _kind, tlines in sorted_threads:
         new_body += "\n" + "\n".join(tlines) + "\n"
-    content = (header or "") + new_body
+    content = new_body
 
 # --- Output ---
 

--- a/.mise/tasks/ls
+++ b/.mise/tasks/ls
@@ -13,14 +13,13 @@ fi
 output=$(HUMAN_PATH="$THREADS_PATH" PYTHONPATH="$MISE_CONFIG_ROOT/lib" python3 << 'PYEOF'
 import os
 from human_threads import (
-    split_header_body, parse_threads, extract_thread_body,
+    parse_threads, extract_thread_body,
     extract_authors, extract_message_senders, extract_all_participants,
     extract_thread_starter, thread_title, thread_waiting_on,
 )
 
 content = open(os.environ["HUMAN_PATH"]).read()
-header, body = split_header_body(content)
-_, threads = parse_threads(body)
+_, threads = parse_threads(content)
 
 if not threads:
     print("NO_THREADS")

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -13,13 +13,12 @@ fi
 HUMAN_PATH="$THREADS_PATH" PYTHONPATH="$MISE_CONFIG_ROOT/lib" python3 << 'PYEOF'
 import os
 from human_threads import (
-    split_header_body, parse_threads, extract_thread_body,
+    parse_threads, extract_thread_body,
     extract_message_senders, thread_waiting_on,
 )
 
 content = open(os.environ["HUMAN_PATH"]).read()
-_, body = split_header_body(content)
-_, threads = parse_threads(body)
+_, threads = parse_threads(content)
 
 counts = {"agent": 0, "or": 0, "resolved": 0, "unknown": 0}
 

--- a/lib/human_threads.py
+++ b/lib/human_threads.py
@@ -7,26 +7,11 @@ from HUMAN.md files.
 import os
 import re
 
-HEADER_MARKER = "--- HEADER END ---"
-
 CALLOUT_OPENER = re.compile(r"^> \[!(info|note|warning|success)\][+-]?\s*")
 # Matches [Name] or **[Name]** or **[Name1 → Name2]** etc.
 # Uses greedy match and includes digits for names like x1f9, k7r2.
 NAME_PAT = re.compile(r"^(?:\*\*)?\[([A-Za-z0-9][A-Za-z0-9 →\-]*)\](?:\*\*)?")
 ARROW_SEP = re.compile(r"\s*→\s*")
-
-
-def split_header_body(content):
-    """Split content at the header marker.
-
-    Returns (header, body) where header includes the marker line.
-    If no marker found, returns (None, content).
-    """
-    idx = content.find(HEADER_MARKER)
-    if idx < 0:
-        return None, content
-    end = idx + len(HEADER_MARKER)
-    return content[:end], content[end:]
 
 
 def parse_threads(body):

--- a/test/parser.bats
+++ b/test/parser.bats
@@ -5,28 +5,30 @@ setup() {
   load helpers
 }
 
-# --- split_header_body ---
+# --- _resolve-file ---
 
-@test "parser: splits at header marker" {
-  run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
-from human_threads import split_header_body
-h, b = split_header_body('# Title\n--- HEADER END ---\nbody')
-assert h == '# Title\n--- HEADER END ---', f'header: {h!r}'
-assert b == '\nbody', f'body: {b!r}'
-"
+@test "_resolve-file: absolute path passes through" {
+  run bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "/tmp/absolute/HUMAN.md"
   [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/absolute/HUMAN.md" ]
 }
 
-@test "parser: no marker returns None header" {
-  run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
-from human_threads import split_header_body
-h, b = split_header_body('no marker here')
-assert h is None
-assert b == 'no marker here'
-"
+@test "_resolve-file: relative path resolves against CALLER_PWD" {
+  run env CALLER_PWD="/tmp/caller" bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "notes/BULLETIN.md"
   [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/caller/notes/BULLETIN.md" ]
+}
+
+@test "_resolve-file: no arg defaults to CALLER_PWD/HUMAN.md" {
+  run env CALLER_PWD="/tmp/caller" THREADS_FILE= bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/caller/HUMAN.md" ]
+}
+
+@test "_resolve-file: THREADS_FILE env is also CWD-relative" {
+  run env CALLER_PWD="/tmp/caller" THREADS_FILE="notes/B.md" bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/caller/notes/B.md" ]
 }
 
 # --- parse_threads ---


### PR DESCRIPTION
Two fixes, both small.

## 1. `_resolve-file` CWD-relative paths

`threads <cmd> --file notes/BULLETIN.md` was failing with "No threads file found" — the task runs from `$MISE_CONFIG_ROOT` so a relative path would be resolved against the mise install dir instead of the caller's CWD. Now `_resolve-file` joins relative paths to `$CALLER_PWD` before emitting them. Absolute paths still pass through unchanged.

Hit during a BULLETIN.md archive pass — running `threads archive --file notes/BULLETIN.md` from the den clone should Just Work; today the workaround is `THREADS_FILE="$(pwd)/notes/BULLETIN.md" threads archive`.

## 2. Remove dead `HEADER_MARKER` / `split_header_body`

The `--- HEADER END ---` marker isn't used by any live file (not HUMAN.md, not BULLETIN.md). Every task was already tolerant of its absence via `(header or "")`. Removed the constant, the function, the unused `import` in each task, and the no-op re-assembly.

## Tests

- 4 new bats for `_resolve-file` (absolute, relative, default, THREADS_FILE env)
- 2 `split_header_body` tests removed
- Full suite: **56/56 pass**