### PR TITLE
Treat thread messages as newest-first

### DIFF
--- a/.mise/tasks/fmt
+++ b/.mise/tasks/fmt
@@ -50,22 +50,46 @@ def replace_codeblock(match):
         return match.group(0)
 
     title = "TODO: title this thread"
-    callout_lines = [f"> [!note]- {title}"]
-    first_message = True
+    # Raw pasted transcripts are usually written oldest-first. Threads use
+    # newest-first order, so convert whole message blocks in reverse.
+    message_blocks = []
+    current_block = []
+    leading_lines = []
+
     for line in lines:
         stripped = line.strip()
-        if stripped == "":
-            callout_lines.append(">")
-        elif NAME_PAT.match(stripped):
-            if not first_message:
-                callout_lines.append(">")
-                callout_lines.append("> ---")
-                callout_lines.append(">")
-            bolded = NAME_PAT.sub(lambda name: f"**[{name.group(1)}]**", stripped)
-            callout_lines.append(f"> {bolded}")
-            first_message = False
+        if NAME_PAT.match(stripped):
+            if current_block:
+                message_blocks.append(current_block)
+            current_block = [line]
+        elif current_block:
+            current_block.append(line)
         else:
-            callout_lines.append(f"> {line}")
+            leading_lines.append(line)
+
+    if current_block:
+        message_blocks.append(current_block)
+
+    if leading_lines and message_blocks:
+        message_blocks[0] = leading_lines + message_blocks[0]
+
+    callout_lines = [f"> [!note]- {title}"]
+    first_message = True
+    for block in reversed(message_blocks):
+        if not first_message:
+            callout_lines.append(">")
+            callout_lines.append("> ---")
+            callout_lines.append(">")
+        for line in block:
+            stripped = line.strip()
+            if stripped == "":
+                callout_lines.append(">")
+            elif NAME_PAT.match(stripped):
+                bolded = NAME_PAT.sub(lambda name: f"**[{name.group(1)}]**", stripped)
+                callout_lines.append(f"> {bolded}")
+            else:
+                callout_lines.append(f"> {line}")
+        first_message = False
 
     converted += 1
     return "\n".join(callout_lines) + "\n"

--- a/.mise/tasks/ls
+++ b/.mise/tasks/ls
@@ -9,7 +9,6 @@ import sys
 sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
 from human_threads import (  # noqa: E402
     extract_all_participants,
-    extract_authors,
     extract_message_senders,
     extract_thread_body,
     extract_thread_starter,
@@ -46,16 +45,15 @@ def run_gum(*args, input_text=None):
 if not threads:
     run_gum("style", "--faint", "No threads found")
 else:
-    # Participants column encodes roles: + = started thread, * = last sender
+    # Participants column encodes roles: + = started thread, * = latest sender
     rows = [["Status", "Thread", "Participants", "Waiting on"]]
     for kind, lines in threads:
         title = thread_title(lines[0])
         body_lines = extract_thread_body(lines)
-        authors = extract_authors(body_lines)
         senders = extract_message_senders(body_lines)
         participants = extract_all_participants(body_lines)
         starter = extract_thread_starter(body_lines)
-        last_author = authors[-1] if authors else None
+        latest_sender = senders[0] if senders else None
         waiting = thread_waiting_on(kind, senders)
 
         annotated = []
@@ -63,7 +61,7 @@ else:
             suffix = ""
             if name == starter:
                 suffix += "+"
-            if name == last_author:
+            if name == latest_sender:
                 suffix += "*"
             annotated.append(name + suffix)
 
@@ -98,4 +96,4 @@ else:
         "81",
         input_text=table_input,
     )
-    run_gum("style", "--faint", "  + started thread  * last sender")
+    run_gum("style", "--faint", "  + started thread  * latest sender")

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Parse, format, and archive [Obsidian-style callout](https://help.obsidian.md/cal
 The async communication layer for humans and agents.
 
 ![lang: python + bash](https://img.shields.io/badge/lang-python%20%2B%20bash-3776AB?style=flat&logo=python&logoColor=white)
-[![tests: 58 passing](https://img.shields.io/badge/tests-58%20passing-brightgreen?style=flat)](test/)
+[![tests: 60 passing](https://img.shields.io/badge/tests-60%20passing-brightgreen?style=flat)](test/)
 ![commands: 5](https://img.shields.io/badge/commands-5-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -27,8 +27,7 @@ $ cat HUMAN.md
 # A human writes raw thoughts anywhere in the file:
 
   [Or] We should add retry logic to the webhook handler.
-  [ikma] Agree — exponential backoff with jitter?
-  [Or] Yeah. Can you draft it?
+  [ikma] Agree — exponential backoff with jitter. I can draft it.
 
 $ threads fmt
 Formatted: converted 1 codeblock, promoted 1 to warning, sorted.
@@ -40,15 +39,11 @@ $ cat HUMAN.md
 > ...
 
 > [!warning]- TODO: title this thread 👈
+> **[ikma]** Agree — exponential backoff with jitter. I can draft it.
+>
+> ---
+>
 > **[Or]** We should add retry logic to the webhook handler.
->
-> ---
->
-> **[ikma]** Agree — exponential backoff with jitter?
->
-> ---
->
-> **[Or]** Yeah. Can you draft it?
 ```
 
 <br />
@@ -104,9 +99,11 @@ A threads file is plain markdown — a flat sequence of [Obsidian callouts](http
 - `[!note]-` — active thread
 - `[!success]-` — resolved (ready to archive)
 
-Messages within a thread start with `**[Name]**`, separated by `> ---` dividers. Arrow notation tracks rewrites: `**[Or → ikma]**` means "Or's words, as rewritten by ikma."
+Messages within a thread start with `**[Name]**`, newest-first, separated by `> ---` dividers. Add new replies at the top of the thread. Arrow notation tracks rewrites: `**[Or → ikma]**` means "Or's words, as rewritten by ikma."
 
-**Turn-taking drives automation.** The last sender determines who's waiting. If a human sent the last message, agents are waiting. If an agent replied, the human is waiting. `fmt` uses this to auto-promote threads to `[!warning]` when they need human attention, demote back to `[!note]` when the human has replied, and sort warnings to the top.
+**Turn-taking drives automation.** The latest sender determines who's waiting. If a human sent the latest message, agents are waiting. If an agent replied, the human is waiting. `fmt` uses this to auto-promote threads to `[!warning]` when they need human attention, demote back to `[!note]` when the human has replied, and sort warnings to the top.
+
+`fmt` treats existing message order as authoritative; it does not reshuffle messages inside established threads. Raw codeblock transcripts are converted into newest-first callouts.
 
 The human name defaults to `Or` but is configurable via `THREADS_HUMAN`. When unset, turn-taking is disabled — useful for peer-to-peer files like bulletin boards where there's no human in the loop.
 
@@ -119,10 +116,10 @@ $ threads ls
 ├───────────┼──────────────────────────────────────┼───────────────────┼────────────┤
 │ info      │ How this works                       │ —                 │ —          │
 │ attention │ Retry logic for webhook handler      │ Or+, ikma*        │ Or         │
-│ active    │ Refactor auth module                 │ ikma+*, Or        │ agent      │
+│ active    │ Refactor auth module                 │ ikma+, Or*        │ agent      │
 │ resolved  │ Fix CI timeout                       │ Or+, baby-joel*   │ resolved   │
 ╰───────────┴──────────────────────────────────────┴───────────────────┴────────────╯
-  + started thread  * last sender
+  + started thread  * latest sender
 
 $ threads fmt
 Formatted: promoted 1 to warning, sorted.
@@ -158,7 +155,7 @@ cd threads && mise trust && mise install
 mise run test
 ```
 
-**58 tests** across 6 suites. The parser is 255 lines of Python in `lib/human_threads.py`. Core commands are Python mise file tasks that call into the shared parser; shell remains for small wrappers and tests. Templates use [farts](https://github.com/KnickKnackLabs/farts) for frontmatter.
+**60 tests** across 6 suites. The parser is 262 lines of Python in `lib/human_threads.py`. Core commands are Python mise file tasks that call into the shared parser; shell remains for small wrappers and tests. Templates use [farts](https://github.com/KnickKnackLabs/farts) for frontmatter.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -176,7 +173,7 @@ threads/
 ├── templates/
 │   └── *.md               # 1 template(s) with frontmatter metadata
 └── test/
-    └── *.bats             # 58 tests
+    └── *.bats             # 60 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -76,8 +76,7 @@ const readme = (
       "# A human writes raw thoughts anywhere in the file:",
       "",
       "  [Or] We should add retry logic to the webhook handler.",
-      "  [ikma] Agree — exponential backoff with jitter?",
-      "  [Or] Yeah. Can you draft it?",
+      "  [ikma] Agree — exponential backoff with jitter. I can draft it.",
       "",
       "$ threads fmt",
       "Formatted: converted 1 codeblock, promoted 1 to warning, sorted.",
@@ -89,15 +88,11 @@ const readme = (
       "> ...",
       "",
       "> [!warning]- TODO: title this thread 👈",
+      "> **[ikma]** Agree — exponential backoff with jitter. I can draft it.",
+      ">",
+      "> ---",
+      ">",
       "> **[Or]** We should add retry logic to the webhook handler.",
-      ">",
-      "> ---",
-      ">",
-      "> **[ikma]** Agree — exponential backoff with jitter?",
-      ">",
-      "> ---",
-      ">",
-      "> **[Or]** Yeah. Can you draft it?",
     ].join("\n")}</CodeBlock>
 
     <LineBreak />
@@ -173,22 +168,27 @@ const readme = (
       <Paragraph>
         {"Messages within a thread start with "}
         <Code>{"**[Name]**"}</Code>
-        {", separated by "}
+        {", newest-first, separated by "}
         <Code>{"> ---"}</Code>
-        {" dividers. Arrow notation tracks rewrites: "}
+        {" dividers. Add new replies at the top of the thread. Arrow notation tracks rewrites: "}
         <Code>{"**[Or → ikma]**"}</Code>
         {" means \"Or's words, as rewritten by ikma.\""}
       </Paragraph>
 
       <Paragraph>
         <Bold>{"Turn-taking drives automation."}</Bold>
-        {" The last sender determines who's waiting. If a human sent the last message, agents are waiting. If an agent replied, the human is waiting. "}
+        {" The latest sender determines who's waiting. If a human sent the latest message, agents are waiting. If an agent replied, the human is waiting. "}
         <Code>fmt</Code>
         {" uses this to auto-promote threads to "}
         <Code>[!warning]</Code>
         {" when they need human attention, demote back to "}
         <Code>[!note]</Code>
         {" when the human has replied, and sort warnings to the top."}
+      </Paragraph>
+
+      <Paragraph>
+        <Code>fmt</Code>
+        {" treats existing message order as authoritative; it does not reshuffle messages inside established threads. Raw codeblock transcripts are converted into newest-first callouts."}
       </Paragraph>
 
       <Paragraph>
@@ -208,10 +208,10 @@ const readme = (
         "├───────────┼──────────────────────────────────────┼───────────────────┼────────────┤",
         "│ info      │ How this works                       │ —                 │ —          │",
         "│ attention │ Retry logic for webhook handler      │ Or+, ikma*        │ Or         │",
-        "│ active    │ Refactor auth module                 │ ikma+*, Or        │ agent      │",
+        "│ active    │ Refactor auth module                 │ ikma+, Or*        │ agent      │",
         "│ resolved  │ Fix CI timeout                       │ Or+, baby-joel*   │ resolved   │",
         "╰───────────┴──────────────────────────────────────┴───────────────────┴────────────╯",
-        "  + started thread  * last sender",
+        "  + started thread  * latest sender",
         "",
         "$ threads fmt",
         "Formatted: promoted 1 to warning, sorted.",

--- a/lib/human_threads.py
+++ b/lib/human_threads.py
@@ -146,13 +146,14 @@ def parse_author_chain(raw):
 
 
 def extract_authors(body_lines):
-    """Extract author names from body lines, in order of appearance.
+    """Extract author names from body lines, in file order.
 
-    Supports arrow chain convention: **[Or → Zeke]** yields both names.
-    The returned list is flattened — each message contributes its chain's
-    last name as the "effective author" for editor attribution (the '*'
-    last-editor annotation in `list` output). For turn-taking / waiting-on
-    logic, use `extract_message_senders()` instead.
+    Threads use newest-first message order, so the first returned author is
+    from the latest message. Supports arrow chain convention: **[Or → Zeke]**
+    yields both names. The returned list is flattened — each message
+    contributes its chain's last name as the "effective author" for editor
+    attribution. For turn-taking / waiting-on logic, use
+    `extract_message_senders()` instead.
     """
     authors = []
     for line in body_lines:
@@ -167,11 +168,12 @@ def extract_authors(body_lines):
 
 
 def extract_message_senders(body_lines):
-    """Extract the original sender of each message, in order.
+    """Extract the original sender of each message, in file order.
 
-    For arrow chains like **[Or → Zeke]**, returns 'Or' (the original
-    author), not 'Zeke' (the editor). Use this for turn-taking logic
-    (thread_waiting_on) where we care about who *sent* the message,
+    Threads use newest-first message order, so the first returned sender is
+    the latest sender. For arrow chains like **[Or → Zeke]**, returns 'Or'
+    (the original author), not 'Zeke' (the editor). Use this for turn-taking
+    logic (thread_waiting_on) where we care about who *sent* the message,
     not who cleaned up its prose.
 
     Contrast with extract_authors which returns the last name in each
@@ -203,16 +205,20 @@ def extract_all_participants(body_lines):
 
 
 def extract_thread_starter(body_lines):
-    """Return the original author of the first message in a thread.
+    """Return the original author of the oldest message in a thread.
 
-    For a chain like [Or → x1f9], returns 'Or' (the original author).
+    Threads use newest-first message order, so the starter is the last
+    sender found in file order. For a chain like [Or → x1f9], returns 'Or'
+    (the original author).
     """
+    starter = None
     for line in body_lines:
         m = NAME_PAT.match(line)
         if m:
             chain = parse_author_chain(m.group(1))
-            return chain[0] if chain else None
-    return None
+            if chain:
+                starter = chain[0]
+    return starter
 
 
 def thread_title(opener_line):
@@ -237,19 +243,20 @@ def _resolve_human_name(human_name=None):
     return os.environ.get("THREADS_HUMAN")
 
 
-def thread_waiting_on(kind, authors, human_name=None):
+def thread_waiting_on(kind, senders, human_name=None):
     """Determine who the thread is waiting on.
 
-    Returns 'resolved', 'agent', the human name, or '\u2014'.
+    Returns 'resolved', 'agent', the human name, or '\u2014'. Threads use
+    newest-first message order, so the first sender is the latest sender.
     The human name is resolved from the explicit argument or the
-    THREADS_HUMAN env var. If neither is set, turn-taking is
-    disabled and all active threads return '\u2014'.
+    THREADS_HUMAN env var. If neither is set, turn-taking is disabled and
+    all active threads return '\u2014'.
     """
     human = _resolve_human_name(human_name)
     if kind == "success":
         return "resolved"
-    if not authors or human is None:
+    if not senders or human is None:
         return "\u2014"
-    if authors[-1] == human:
+    if senders[0] == human:
         return "agent"
     return human

--- a/templates/HUMAN.md
+++ b/templates/HUMAN.md
@@ -11,7 +11,7 @@ description: Default async scratchpad for human-agent conversations
 > - `[!note]-` — regular thread
 > - `[!success]-` — resolved
 >
-> **Messages:** Start with `**[Name]**`, separated by `> ---` dividers.
+> **Messages:** Start with `**[Name]**`, newest-first, separated by `> ---` dividers. Add new replies at the top.
 >
 > **Arrow notation:** `**[Or → agent]**` means Or's words, rewritten by agent.
 >

--- a/test/fmt.bats
+++ b/test/fmt.bats
@@ -16,6 +16,10 @@ setup() {
   content=$(cat "$THREADS_PATH")
   [[ "$content" == *"[!note]"* ]] || [[ "$content" == *"[!warning]"* ]]
   [[ "$content" == *"**[Or]**"* ]]
+  local junior_pos or_pos
+  junior_pos=$(echo "$content" | grep -n "\*\*\[junior\]\*\*" | head -1 | cut -d: -f1)
+  or_pos=$(echo "$content" | grep -n "\*\*\[Or\]\*\*" | head -1 | cut -d: -f1)
+  [ "$junior_pos" -lt "$or_pos" ]
 }
 
 @test "fmt: ignores codeblocks without author markers" {
@@ -80,7 +84,7 @@ no authors here
   write_threads "$THREAD_OR_REWRITTEN_LAST"
   run threads fmt --file "$THREADS_PATH"
   [ "$status" -eq 0 ]
-  # Or spoke last (via rewrite) — should wait on agent, so stays/becomes note
+  # Or spoke latest (via rewrite) — should wait on agent, so stays/becomes note
   run cat "$THREADS_PATH"
   [[ "$output" == *"[!note]"* ]]
 }
@@ -114,11 +118,11 @@ no authors here
 @test "fmt: nothing to format when already correct" {
   # Fixtures where types and order already match what fmt would produce
   local stable_warning='> [!warning]- Or needs to respond 👈
-> **[Or]** Started a thought.
+> **[junior]** Here is my reply.
 >
 > ---
 >
-> **[junior]** Here is my reply.'
+> **[Or]** Started a thought.'
   local stable_note='> [!note]- Agent should handle
 > **[Or]** Please do this.'
   write_threads "$stable_warning" "$stable_note" "$THREAD_SUCCESS"
@@ -131,11 +135,11 @@ no authors here
 
 @test "fmt --check: exits 0 when clean" {
   local stable_warning='> [!warning]- Or needs to respond 👈
-> **[Or]** Started a thought.
+> **[junior]** Here is my reply.
 >
 > ---
 >
-> **[junior]** Here is my reply.'
+> **[Or]** Started a thought.'
   local stable_note='> [!note]- Agent should handle
 > **[Or]** Please do this.'
   write_threads "$stable_warning" "$stable_note" "$THREAD_SUCCESS"
@@ -169,11 +173,11 @@ no authors here
   local info_thread='> [!info]- Instructions
 > How to use this file.'
   local stable_warning='> [!warning]- Or needs to respond \U0001f448
-> **[Or]** Started a thought.
+> **[junior]** Here is my reply.
 >
 > ---
 >
-> **[junior]** Here is my reply.'
+> **[Or]** Started a thought.'
   write_threads "$stable_warning" "$info_thread"
   run threads fmt --file "$THREADS_PATH"
   [ "$status" -eq 0 ]

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -50,13 +50,14 @@ ${thread}
 }
 
 # --- Standard thread fixtures ---
+# Messages inside a thread are newest-first: add replies at the top.
 
 THREAD_NOTE='> [!note]- Test thread (Mar 15)
-> **[Or]** This is a test note.
+> **[junior]** Noted.
 >
 > ---
 >
-> **[junior]** Noted.'
+> **[Or]** This is a test note.'
 
 THREAD_WARNING='> [!warning]- Urgent thing 👈
 > **[Or]** This needs attention.'
@@ -71,22 +72,22 @@ THREAD_AGENT_WAITING='> [!note]- Agent should respond
 > **[Or]** What do you think?'
 
 THREAD_OR_WAITING='> [!note]- Or should respond
-> **[Or]** Starting thought.
+> **[junior]** Here is my response.
 >
 > ---
 >
-> **[junior]** Here is my response.'
+> **[Or]** Starting thought.'
 
 THREAD_NO_AUTHORS='> [!note]- Empty thread
 > No author markers here.'
 
 # Thread with arrow chain authorship convention
 THREAD_ARROW_CHAIN='> [!note]- Rewritten thread (Mar 15)
-> **[Or → x1f9]** This message was clarified by x1f9.
+> **[junior]** Looks good to me.
 >
 > ---
 >
-> **[junior]** Looks good to me.'
+> **[Or → x1f9]** This message was clarified by x1f9.'
 
 # Thread with multi-hop arrow chain
 THREAD_MULTI_ARROW='> [!note]- Multi-edit thread
@@ -94,33 +95,33 @@ THREAD_MULTI_ARROW='> [!note]- Multi-edit thread
 
 # Thread where Or's message was rewritten by an agent (arrow notation)
 THREAD_OR_REWRITTEN_BY_AGENT='> [!note]- Or said something, agent rewrote
-> **[Or → Zeke]** This is Or speaking, Zeke just cleaned up the prose.
+> **[Zeke]** My actual response to Or.
 >
 > ---
 >
-> **[Zeke]** My actual response to Or.'
+> **[Or → Zeke]** This is Or speaking, Zeke just cleaned up the prose.'
 
-# Thread where agent's rewrite is the last message (should wait on agent)
-THREAD_OR_REWRITTEN_LAST='> [!note]- Or spoke last via rewrite
-> **[Zeke]** I said something first.
+# Thread where Or's rewritten message is the latest message (should wait on agent)
+THREAD_OR_REWRITTEN_LAST='> [!note]- Or spoke latest via rewrite
+> **[Or → Zeke]** Or replied, Zeke cleaned it up.
 >
 > ---
 >
-> **[Or → Zeke]** Or replied, Zeke cleaned it up.'
+> **[Zeke]** I said something first.'
 
 # Thread with multi-paragraph content (blank lines inside callout)
 THREAD_MULTI_PARAGRAPH='> [!note]- Long discussion (Mar 15)
+> **[junior]** My multi-paragraph reply.
+>
+> Continued thoughts here.
+>
+> ---
+>
 > **[Or]** First paragraph of thought.
 >
 > Second paragraph continues here.
 >
-> Third paragraph with more detail.
->
-> ---
->
-> **[junior]** My multi-paragraph reply.
->
-> Continued thoughts here.'
+> Third paragraph with more detail.'
 
 # Two adjacent threads separated by a blank line
 THREAD_ADJACENT_A='> [!note]- Thread A

--- a/test/ls.bats
+++ b/test/ls.bats
@@ -33,6 +33,16 @@ setup() {
   [[ "$output" == *"junior"* ]]
 }
 
+@test "ls: marks starter and latest sender in newest-first threads" {
+  write_threads "$THREAD_NOTE"
+
+  run threads ls --file "$THREADS_PATH"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Or+"* ]]
+  [[ "$output" == *"junior*"* ]]
+  [[ "$output" == *"latest sender"* ]]
+}
+
 @test "ls: shows word-based status labels" {
   write_threads "$THREAD_INFO" "$THREAD_WARNING" "$THREAD_NOTE" "$THREAD_SUCCESS"
 

--- a/test/parser.bats
+++ b/test/parser.bats
@@ -151,9 +151,20 @@ assert senders == ['Or'], f'got: {senders}'
   [ "$status" -eq 0 ]
 }
 
+@test "parser: thread starter is oldest sender in newest-first order" {
+  run python3 -c "
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
+from human_threads import extract_thread_starter
+lines = ['**[junior]** Latest reply.', '', '---', '', '**[Or → Zeke]** Original request.']
+starter = extract_thread_starter(lines)
+assert starter == 'Or', f'got: {starter}'
+"
+  [ "$status" -eq 0 ]
+}
+
 # --- thread_waiting_on ---
 
-@test "parser: human last sender means waiting on agent" {
+@test "parser: human latest sender means waiting on agent" {
   run python3 -c "
 import sys, os; sys.path.insert(0, '$REPO_DIR/lib')
 os.environ['THREADS_HUMAN'] = 'Or'
@@ -163,12 +174,12 @@ assert thread_waiting_on('note', ['Or']) == 'agent'
   [ "$status" -eq 0 ]
 }
 
-@test "parser: agent last sender means waiting on human" {
+@test "parser: agent latest sender means waiting on human" {
   run python3 -c "
 import sys, os; sys.path.insert(0, '$REPO_DIR/lib')
 os.environ['THREADS_HUMAN'] = 'Or'
 from human_threads import thread_waiting_on
-assert thread_waiting_on('note', ['Or', 'junior']) == 'Or'
+assert thread_waiting_on('note', ['junior', 'Or']) == 'Or'
 "
   [ "$status" -eq 0 ]
 }
@@ -196,7 +207,7 @@ assert thread_waiting_on('note', []) == '—'
 import sys, os; sys.path.insert(0, '$REPO_DIR/lib')
 os.environ.pop('THREADS_HUMAN', None)
 from human_threads import thread_waiting_on
-assert thread_waiting_on('note', ['Or', 'junior']) == '—'
+assert thread_waiting_on('note', ['junior', 'Or']) == '—'
 assert thread_waiting_on('warning', ['junior']) == '—'
 assert thread_waiting_on('success', ['Or']) == 'resolved'
 "


### PR DESCRIPTION
## Summary
- Switch turn-taking semantics to treat the first message in each thread as the latest message
- Mark thread starters from the oldest message and latest senders from the first message in `threads ls`
- Convert raw codeblock transcripts into newest-first callouts
- Update docs/templates/tests for the new convention

## Scope note
This PR addresses newest-first **message order within each thread**. It does not fully close #2, because thread-level recency ordering still needs a separate convention/tooling decision: probably physical order within status groups, updated by a future `threads reply` / `threads touch` command rather than timestamps in every message.

## Tests
- `mise run test` (58/58)
- `git diff --check`
- `bash -n .mise/tasks/fmt .mise/tasks/ls .mise/tasks/status .mise/tasks/archive`

Related #2
