### PR TITLE
feat: support lifecycle callouts

### DIFF
--- a/.mise/tasks/fmt
+++ b/.mise/tasks/fmt
@@ -80,7 +80,7 @@ if threads:
     new_threads = []
 
     for kind, lines in threads:
-        if kind in ("info", "success"):
+        if kind not in ("note", "warning"):
             new_threads.append((kind, lines))
             continue
 
@@ -116,9 +116,17 @@ if threads:
     if demoted > 0:
         changes.append(f"demoted {demoted} to note")
 
-    # --- Phase 3: Sort threads by type ---
-    sort_key = {"info": 0, "warning": 1, "note": 2, "success": 3}
-    sorted_threads = sorted(new_threads, key=lambda t: sort_key.get(t[0], 3))
+    # --- Phase 3: Sort threads by lifecycle type ---
+    sort_key = {
+        "info": 0,
+        "warning": 1,
+        "todo": 2,
+        "question": 3,
+        "note": 4,
+        "abstract": 5,
+        "success": 6,
+    }
+    sorted_threads = sorted(new_threads, key=lambda t: sort_key.get(t[0], 6))
 
     if sorted_threads != new_threads:
         changes.append("sorted")

--- a/.mise/tasks/ls
+++ b/.mise/tasks/ls
@@ -45,7 +45,15 @@ else:
                 suffix += "*"
             annotated.append(name + suffix)
 
-        status_map = {"info": "info", "warning": "attention", "note": "active", "success": "resolved"}
+        status_map = {
+            "info": "info",
+            "warning": "attention",
+            "todo": "todo",
+            "question": "shaping",
+            "note": "active",
+            "abstract": "parked",
+            "success": "resolved",
+        }
         status = status_map.get(kind, kind)
 
         print("\t".join([

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Parse, format, and archive [Obsidian-style callout](https://help.obsidian.md/cal
 The async communication layer for humans and agents.
 
 ![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 54 passing](https://img.shields.io/badge/tests-54%20passing-brightgreen?style=flat)](test/)
+[![tests: 60 passing](https://img.shields.io/badge/tests-60%20passing-brightgreen?style=flat)](test/)
 ![commands: 5](https://img.shields.io/badge/commands-5-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -99,14 +99,17 @@ threads template          # list available templates
 
 A threads file is plain markdown — a flat sequence of [Obsidian callouts](https://help.obsidian.md/callouts), each representing a conversation thread:
 
-- `[!info]-` — pinned instructions (always at top, never reordered)
 - `[!warning]- 👈` — needs human attention
-- `[!note]-` — active thread
+- `[!todo]-` — ready for agent action, filing, or implementation
+- `[!question]-` — still being shaped; discussion or decision needed
+- `[!note]-` — regular active thread
+- `[!info]-` — pinned instructions, reference, or status only
+- `[!abstract]-` — parked thought / someday-maybe
 - `[!success]-` — resolved (ready to archive)
 
 Messages within a thread start with `**[Name]**`, separated by `> ---` dividers. Arrow notation tracks rewrites: `**[Or → ikma]**` means "Or's words, as rewritten by ikma."
 
-**Turn-taking drives automation.** The last sender determines who's waiting. If a human sent the last message, agents are waiting. If an agent replied, the human is waiting. `fmt` uses this to auto-promote threads to `[!warning]` when they need human attention, demote back to `[!note]` when the human has replied, and sort warnings to the top.
+**Turn-taking drives automation.** The last sender determines who's waiting. If a human sent the last message, agents are waiting. If an agent replied, the human is waiting. `fmt` uses this to auto-promote legacy active threads to `[!warning]` when they need human attention, demote them back to `[!note]` when the human has replied, and sort callouts by lifecycle state. Explicit lifecycle callouts like `[!todo]`, `[!question]`, and `[!abstract]` keep their type.
 
 The human name defaults to `Or` but is configurable via `THREADS_HUMAN`. When unset, turn-taking is disabled — useful for peer-to-peer files like bulletin boards where there's no human in the loop.
 
@@ -158,7 +161,7 @@ cd threads && mise trust && mise install
 mise run test
 ```
 
-**54 tests** across 6 suites. The parser is 244 lines of Python in `lib/human_threads.py`. Tasks are bash scripts that call into the parser for the heavy lifting. Templates use [farts](https://github.com/KnickKnackLabs/farts) for frontmatter.
+**60 tests** across 6 suites. The parser is 229 lines of Python in `lib/human_threads.py`. Tasks are bash scripts that call into the parser for the heavy lifting. Templates use [farts](https://github.com/KnickKnackLabs/farts) for frontmatter.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -176,7 +179,7 @@ threads/
 ├── templates/
 │   └── *.md               # 1 template(s) with frontmatter metadata
 └── test/
-    └── *.bats             # 54 tests
+    └── *.bats             # 60 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -153,16 +153,28 @@ const readme = (
 
       <List>
         <Item>
-          <Code>{"[!info]-"}</Code>
-          {" — pinned instructions (always at top, never reordered)"}
-        </Item>
-        <Item>
           <Code>{"[!warning]- 👈"}</Code>
           {" — needs human attention"}
         </Item>
         <Item>
+          <Code>{"[!todo]-"}</Code>
+          {" — ready for agent action, filing, or implementation"}
+        </Item>
+        <Item>
+          <Code>{"[!question]-"}</Code>
+          {" — still being shaped; discussion or decision needed"}
+        </Item>
+        <Item>
           <Code>{"[!note]-"}</Code>
-          {" — active thread"}
+          {" — regular active thread"}
+        </Item>
+        <Item>
+          <Code>{"[!info]-"}</Code>
+          {" — pinned instructions, reference, or status only"}
+        </Item>
+        <Item>
+          <Code>{"[!abstract]-"}</Code>
+          {" — parked thought / someday-maybe"}
         </Item>
         <Item>
           <Code>{"[!success]-"}</Code>
@@ -184,11 +196,17 @@ const readme = (
         <Bold>{"Turn-taking drives automation."}</Bold>
         {" The last sender determines who's waiting. If a human sent the last message, agents are waiting. If an agent replied, the human is waiting. "}
         <Code>fmt</Code>
-        {" uses this to auto-promote threads to "}
+        {" uses this to auto-promote legacy active threads to "}
         <Code>[!warning]</Code>
-        {" when they need human attention, demote back to "}
+        {" when they need human attention, demote them back to "}
         <Code>[!note]</Code>
-        {" when the human has replied, and sort warnings to the top."}
+        {" when the human has replied, and sort callouts by lifecycle state. Explicit lifecycle callouts like "}
+        <Code>[!todo]</Code>
+        {", "}
+        <Code>[!question]</Code>
+        {", and "}
+        <Code>[!abstract]</Code>
+        {" keep their type."}
       </Paragraph>
 
       <Paragraph>

--- a/lib/human_threads.py
+++ b/lib/human_threads.py
@@ -1,13 +1,13 @@
 """Shared parser for HUMAN.md thread management.
 
-Parses Obsidian-style callout threads ([!info], [!note], [!warning], [!success])
-from HUMAN.md files.
+Parses Obsidian-style callout threads from HUMAN.md files.
 """
 
 import os
 import re
 
-CALLOUT_OPENER = re.compile(r"^> \[!(info|note|warning|success)\][+-]?\s*")
+THREAD_KINDS = ("info", "note", "warning", "todo", "question", "abstract", "success")
+CALLOUT_OPENER = re.compile(r"^> \[!(" + "|".join(THREAD_KINDS) + r")\][+-]?\s*")
 # Matches [Name] or **[Name]** or **[Name1 → Name2]** etc.
 # Uses greedy match and includes digits for names like x1f9, k7r2.
 NAME_PAT = re.compile(r"^(?:\*\*)?\[([A-Za-z0-9][A-Za-z0-9 →\-]*)\](?:\*\*)?")
@@ -21,7 +21,7 @@ def parse_threads(body):
     handle threads separated by blank lines.
 
     Returns (preamble_lines, threads) where threads is a list of
-    (kind, lines) tuples. kind is 'note', 'warning', or 'success'.
+    (kind, lines) tuples. kind is one of THREAD_KINDS.
     """
     lines = body.split("\n")
     preamble_lines = []

--- a/templates/HUMAN.md
+++ b/templates/HUMAN.md
@@ -6,9 +6,13 @@ description: Default async scratchpad for human-agent conversations
 > [!info]- How this works
 > Async scratchpad for human-agent conversations.
 >
-> **Thread types:**
+> **Thread lifecycle:**
 > - `[!warning]- 👈` — needs human's attention
-> - `[!note]-` — regular thread
+> - `[!todo]-` — ready for agent action, filing, or implementation
+> - `[!question]-` — still being shaped; discussion or decision needed
+> - `[!note]-` — regular active thread
+> - `[!info]-` — pinned instructions, reference, or status only
+> - `[!abstract]-` — parked thought / someday-maybe
 > - `[!success]-` — resolved
 >
 > **Messages:** Start with `**[Name]**`, separated by `> ---` dividers.

--- a/test/fmt.bats
+++ b/test/fmt.bats
@@ -194,6 +194,48 @@ no authors here
   [[ "$content" == *"[!info]"* ]]
 }
 
+@test "fmt: does not promote/demote lifecycle callouts" {
+  export THREADS_HUMAN=Or
+  write_threads "$THREAD_TODO" "$THREAD_QUESTION" "$THREAD_ABSTRACT"
+  run threads fmt --file "$THREADS_PATH"
+  [ "$status" -eq 0 ]
+  content=$(cat "$THREADS_PATH")
+  [[ "$content" == *"[!todo]"* ]]
+  [[ "$content" == *"[!question]"* ]]
+  [[ "$content" == *"[!abstract]"* ]]
+}
+
+@test "fmt: sorts lifecycle callouts" {
+  write_threads \
+    "$THREAD_SUCCESS" \
+    "$THREAD_ABSTRACT" \
+    "$THREAD_NOTE" \
+    "$THREAD_QUESTION" \
+    "$THREAD_TODO" \
+    "$THREAD_WARNING" \
+    "$THREAD_INFO"
+  run threads fmt --file "$THREADS_PATH"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sorted"* ]]
+  content=$(cat "$THREADS_PATH")
+
+  local info_pos warning_pos todo_pos question_pos note_pos abstract_pos success_pos
+  info_pos=$(echo "$content" | grep -n "\[!info\]" | head -1 | cut -d: -f1)
+  warning_pos=$(echo "$content" | grep -n "\[!warning\]" | head -1 | cut -d: -f1)
+  todo_pos=$(echo "$content" | grep -n "\[!todo\]" | head -1 | cut -d: -f1)
+  question_pos=$(echo "$content" | grep -n "\[!question\]" | head -1 | cut -d: -f1)
+  note_pos=$(echo "$content" | grep -n "\[!note\]" | head -1 | cut -d: -f1)
+  abstract_pos=$(echo "$content" | grep -n "\[!abstract\]" | head -1 | cut -d: -f1)
+  success_pos=$(echo "$content" | grep -n "\[!success\]" | head -1 | cut -d: -f1)
+
+  [ "$info_pos" -lt "$warning_pos" ]
+  [ "$warning_pos" -lt "$todo_pos" ]
+  [ "$todo_pos" -lt "$question_pos" ]
+  [ "$question_pos" -lt "$note_pos" ]
+  [ "$note_pos" -lt "$abstract_pos" ]
+  [ "$abstract_pos" -lt "$success_pos" ]
+}
+
 # --- Combined operations ---
 
 @test "fmt: converts codeblock and sorts in one pass" {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -65,6 +65,15 @@ THREAD_SUCCESS='> [!success]- Done thing (resolved Mar 15)
 THREAD_INFO='> [!info]- How this works
 > Instructions for using this file.'
 
+THREAD_TODO='> [!todo]- Ready to file
+> **[Or]** Please turn this into an issue.'
+
+THREAD_QUESTION='> [!question]- Still shaping
+> **[Or]** I am not sure what this should become.'
+
+THREAD_ABSTRACT='> [!abstract]- Parked thought
+> **[Or]** Someday maybe.'
+
 THREAD_AGENT_WAITING='> [!note]- Agent should respond
 > **[Or]** What do you think?'
 

--- a/test/ls.bats
+++ b/test/ls.bats
@@ -34,13 +34,23 @@ setup() {
 }
 
 @test "ls: shows word-based status labels" {
-  write_threads "$THREAD_INFO" "$THREAD_WARNING" "$THREAD_NOTE" "$THREAD_SUCCESS"
+  write_threads \
+    "$THREAD_INFO" \
+    "$THREAD_WARNING" \
+    "$THREAD_TODO" \
+    "$THREAD_QUESTION" \
+    "$THREAD_NOTE" \
+    "$THREAD_ABSTRACT" \
+    "$THREAD_SUCCESS"
 
   run threads ls --file "$THREADS_PATH"
   [ "$status" -eq 0 ]
   [[ "$output" == *"info"* ]]
   [[ "$output" == *"attention"* ]]
+  [[ "$output" == *"todo"* ]]
+  [[ "$output" == *"shaping"* ]]
   [[ "$output" == *"active"* ]]
+  [[ "$output" == *"parked"* ]]
   [[ "$output" == *"resolved"* ]]
 }
 

--- a/test/parser.bats
+++ b/test/parser.bats
@@ -93,6 +93,27 @@ assert [t[0] for t in threads] == ['note', 'warning', 'success']
   [ "$status" -eq 0 ]
 }
 
+@test "parser: extracts lifecycle callout threads" {
+  run python3 -c "
+import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+from human_threads import parse_threads, thread_title
+body = '''
+> [!todo]- Ready to file
+> Content A
+
+> [!question]- Still shaping
+> Content B
+
+> [!abstract]- Parked thought
+> Content C
+'''
+_, threads = parse_threads(body)
+assert [t[0] for t in threads] == ['todo', 'question', 'abstract']
+assert [thread_title(t[1][0]) for t in threads] == ['Ready to file', 'Still shaping', 'Parked thought']
+"
+  [ "$status" -eq 0 ]
+}
+
 @test "parser: preserves multi-paragraph content" {
   run python3 -c "
 import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')


### PR DESCRIPTION
## Summary

Adds first-class support for expanded HUMAN.md lifecycle callouts:

- `[!todo]` → `todo`
- `[!question]` → `shaping`
- `[!abstract]` → `parked`

Also keeps existing `info`, `warning`, `note`, and `success` behavior.

## Details

- Parser recognizes the new lifecycle callout types.
- `threads ls` includes them instead of silently dropping those threads.
- `threads fmt` preserves explicit lifecycle types and only auto-promotes/demotes legacy `note`/`warning` turn-taking threads.
- Sorting now follows lifecycle order: `info`, `warning`, `todo`, `question`, `note`, `abstract`, `success`.
- Template and README document the expanded lifecycle.

## Verification

- `mise run test` (60/60)
- `bash -n .mise/tasks/ls .mise/tasks/fmt .mise/tasks/archive .mise/tasks/status .mise/tasks/template`
- `readme build --check`
- `git diff --check`
- Local smoke against Or's updated HUMAN.md shows `todo`, `shaping`, and `parked` rows in `threads ls`.
