### PR TITLE
Migrate thread tasks to Python file tasks

### DIFF
--- a/.mise/tasks/archive
+++ b/.mise/tasks/archive
@@ -1,59 +1,66 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 #MISE description="Move resolved threads to archive file"
-#USAGE flag "--file <file>" help="Path to threads file"
-set -euo pipefail
+#USAGE flag "--file <file>" default="" help="Path to threads file"
 
-THREADS_PATH=$("$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "${usage_file:-}")
-
-if [ ! -f "$THREADS_PATH" ]; then
-  echo "No threads file found at $THREADS_PATH — see available templates: threads template" >&2
-  exit 1
-fi
-
-# Archive lives next to the threads file
-ARCHIVE_PATH="${THREADS_PATH%.md}.archive.md"
-
-HUMAN_PATH="$THREADS_PATH" ARCHIVE_PATH="$ARCHIVE_PATH" PYTHONPATH="$MISE_CONFIG_ROOT/lib" python3 << 'PYEOF'
 import os
+import sys
 from datetime import date
-from human_threads import parse_threads
 
-human_path = os.environ["HUMAN_PATH"]
-archive_path = os.environ["ARCHIVE_PATH"]
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+from human_threads import parse_threads, resolve_threads_path  # noqa: E402
 
-content = open(human_path).read()
+human_path = resolve_threads_path(os.environ.get("usage_file", ""))
+
+if not os.path.isfile(human_path):
+    print(
+        f"No threads file found at {human_path} — see available templates: threads template",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# Archive lives next to the threads file. Preserve the historical shell
+# behavior: strip a trailing .md when present, then append .archive.md.
+archive_path = (
+    human_path[:-3] + ".archive.md"
+    if human_path.endswith(".md")
+    else human_path + ".archive.md"
+)
+
+with open(human_path, encoding="utf-8") as f:
+    content = f.read()
 preamble_lines, threads = parse_threads(content)
 
-kept = [(k, l) for k, l in threads if k != "success"]
-resolved = [(k, l) for k, l in threads if k == "success"]
+kept = [(kind, lines) for kind, lines in threads if kind != "success"]
+resolved = [(kind, lines) for kind, lines in threads if kind == "success"]
 
 if not resolved:
     print("No resolved threads to archive.")
-    raise SystemExit(0)
+    sys.exit(0)
 
-# Append to archive file
+# Append to archive file.
 archive_existed = os.path.exists(archive_path)
-with open(archive_path, "a") as f:
+with open(archive_path, "a", encoding="utf-8") as f:
     if not archive_existed:
-        f.write("""\
+        f.write(
+            """\
 # Archive
 
 Resolved conversation threads.
 
-""")
+"""
+        )
     f.write(f"## Archived {date.today().isoformat()}\n\n")
-    for _kind, tlines in resolved:
-        f.write("\n".join(tlines) + "\n\n")
+    for _kind, thread_lines in resolved:
+        f.write("\n".join(thread_lines) + "\n\n")
 
-# Rewrite threads file without resolved threads
+# Rewrite threads file without resolved threads.
 preamble = "\n".join(preamble_lines).rstrip("\n")
 new_body = preamble + "\n"
-for _kind, tlines in kept:
-    new_body += "\n" + "\n".join(tlines) + "\n"
+for _kind, thread_lines in kept:
+    new_body += "\n" + "\n".join(thread_lines) + "\n"
 
-with open(human_path, "w") as f:
+with open(human_path, "w", encoding="utf-8") as f:
     f.write(new_body)
 
-s = "s" if len(resolved) != 1 else ""
-print(f"Archived {len(resolved)} resolved thread{s} to {os.path.basename(archive_path)}.")
-PYEOF
+suffix = "s" if len(resolved) != 1 else ""
+print(f"Archived {len(resolved)} resolved thread{suffix} to {os.path.basename(archive_path)}.")

--- a/.mise/tasks/fmt
+++ b/.mise/tasks/fmt
@@ -1,29 +1,35 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 #MISE description="Format threads: convert codeblocks, promote/demote, sort"
-#USAGE flag "--file <file>" help="Path to threads file"
-#USAGE flag "--check" help="Check mode: report issues, exit non-zero if changes needed"
-set -euo pipefail
+#USAGE flag "--file <file>" default="" help="Path to threads file"
+#USAGE flag "--check" default=#false help="Check mode: report issues, exit non-zero if changes needed"
 
-THREADS_PATH=$("$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "${usage_file:-}")
+import os
+import re
+import sys
 
-if [ ! -f "$THREADS_PATH" ]; then
-  echo "No threads file found at $THREADS_PATH — see available templates: threads template" >&2
-  exit 1
-fi
-
-CHECK_MODE="${usage_check:-false}"
-
-HUMAN_PATH="$THREADS_PATH" CHECK_MODE="$CHECK_MODE" PYTHONPATH="$MISE_CONFIG_ROOT/lib" python3 << 'PYEOF'
-import re, os, sys
-from human_threads import (
-    NAME_PAT, CALLOUT_OPENER,
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+from human_threads import (  # noqa: E402
+    CALLOUT_OPENER,
+    NAME_PAT,
+    extract_message_senders,
+    extract_thread_body,
     parse_threads,
-    extract_thread_body, extract_message_senders, thread_waiting_on,
+    resolve_threads_path,
+    thread_waiting_on,
 )
 
-filepath = os.environ["HUMAN_PATH"]
-check_mode = os.environ.get("CHECK_MODE", "false") == "true"
-original = open(filepath).read()
+filepath = resolve_threads_path(os.environ.get("usage_file", ""))
+
+if not os.path.isfile(filepath):
+    print(
+        f"No threads file found at {filepath} — see available templates: threads template",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+check_mode = os.environ.get("usage_check", "false") == "true"
+with open(filepath, encoding="utf-8") as f:
+    original = f.read()
 content = original
 changes = []
 
@@ -32,20 +38,22 @@ changes = []
 codeblock_pat = re.compile(r"^```\s*\n(.*?)^```\s*$", re.MULTILINE | re.DOTALL)
 
 converted = 0
-def replace_codeblock(m):
+
+
+def replace_codeblock(match):
     global converted
-    block_content = m.group(1).strip()
+    block_content = match.group(1).strip()
 
     lines = block_content.split("\n")
-    has_messages = any(NAME_PAT.match(l.strip()) for l in lines)
+    has_messages = any(NAME_PAT.match(line.strip()) for line in lines)
     if not has_messages:
-        return m.group(0)
+        return match.group(0)
 
     title = "TODO: title this thread"
     callout_lines = [f"> [!note]- {title}"]
     first_message = True
-    for l in lines:
-        stripped = l.strip()
+    for line in lines:
+        stripped = line.strip()
         if stripped == "":
             callout_lines.append(">")
         elif NAME_PAT.match(stripped):
@@ -53,28 +61,28 @@ def replace_codeblock(m):
                 callout_lines.append(">")
                 callout_lines.append("> ---")
                 callout_lines.append(">")
-            bolded = NAME_PAT.sub(lambda nm: f"**[{nm.group(1)}]**", stripped)
+            bolded = NAME_PAT.sub(lambda name: f"**[{name.group(1)}]**", stripped)
             callout_lines.append(f"> {bolded}")
             first_message = False
         else:
-            callout_lines.append(f"> {l}")
+            callout_lines.append(f"> {line}")
 
     converted += 1
     return "\n".join(callout_lines) + "\n"
+
 
 content = codeblock_pat.sub(replace_codeblock, content)
 content = re.sub(r"\n{4,}", "\n\n\n", content)
 
 if converted > 0:
-    s = "s" if converted != 1 else ""
-    changes.append(f"converted {converted} codeblock{s}")
+    suffix = "s" if converted != 1 else ""
+    changes.append(f"converted {converted} codeblock{suffix}")
 
 # --- Phase 2: Promote/demote thread callout types based on waiting-on ---
 
 preamble_lines, threads = parse_threads(content)
 
 if threads:
-
     promoted = 0
     demoted = 0
     new_threads = []
@@ -98,15 +106,15 @@ if threads:
 
         if new_kind != kind:
             opener = lines[0]
-            m = CALLOUT_OPENER.match(opener)
-            if m:
-                prefix = opener[:m.start(1)]
-                suffix = opener[m.end(1):]
+            opener_match = CALLOUT_OPENER.match(opener)
+            if opener_match:
+                prefix = opener[: opener_match.start(1)]
+                suffix = opener[opener_match.end(1) :]
                 new_opener = prefix + new_kind + suffix
-                if new_kind == "warning" and "\U0001f448" not in new_opener:
-                    new_opener = new_opener.rstrip() + " \U0001f448"
-                elif new_kind != "warning" and "\U0001f448" in new_opener:
-                    new_opener = re.sub(r"\s*\U0001f448\s*", " ", new_opener).rstrip()
+                if new_kind == "warning" and "👈" not in new_opener:
+                    new_opener = new_opener.rstrip() + " 👈"
+                elif new_kind != "warning" and "👈" in new_opener:
+                    new_opener = re.sub(r"\s*👈\s*", " ", new_opener).rstrip()
                 lines = [new_opener] + lines[1:]
 
         new_threads.append((new_kind, lines))
@@ -118,7 +126,7 @@ if threads:
 
     # --- Phase 3: Sort threads by type ---
     sort_key = {"info": 0, "warning": 1, "note": 2, "success": 3}
-    sorted_threads = sorted(new_threads, key=lambda t: sort_key.get(t[0], 3))
+    sorted_threads = sorted(new_threads, key=lambda thread: sort_key.get(thread[0], 3))
 
     if sorted_threads != new_threads:
         changes.append("sorted")
@@ -126,8 +134,8 @@ if threads:
     # Reassemble
     preamble = "\n".join(preamble_lines).rstrip("\n")
     new_body = preamble + "\n"
-    for _kind, tlines in sorted_threads:
-        new_body += "\n" + "\n".join(tlines) + "\n"
+    for _kind, thread_lines in sorted_threads:
+        new_body += "\n" + "\n".join(thread_lines) + "\n"
     content = new_body
 
 # --- Output ---
@@ -136,14 +144,12 @@ if check_mode:
     if changes:
         print(f"Would change: {', '.join(changes)}.")
         sys.exit(1)
-    else:
-        print("Clean.")
-        sys.exit(0)
+    print("Clean.")
+    sys.exit(0)
 
 if changes:
-    with open(filepath, "w") as f:
+    with open(filepath, "w", encoding="utf-8") as f:
         f.write(content)
     print(f"Formatted: {', '.join(changes)}.")
 else:
     print("Nothing to format.")
-PYEOF

--- a/.mise/tasks/ls
+++ b/.mise/tasks/ls
@@ -1,31 +1,53 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 #MISE description="List threads with status and who's waiting"
-#USAGE flag "--file <file>" help="Path to threads file"
-set -euo pipefail
+#USAGE flag "--file <file>" default="" help="Path to threads file"
 
-THREADS_PATH=$("$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "${usage_file:-}")
-
-if [ ! -f "$THREADS_PATH" ]; then
-  echo "No threads file found at $THREADS_PATH — see available templates: threads template" >&2
-  exit 1
-fi
-
-output=$(HUMAN_PATH="$THREADS_PATH" PYTHONPATH="$MISE_CONFIG_ROOT/lib" python3 << 'PYEOF'
 import os
-from human_threads import (
-    parse_threads, extract_thread_body,
-    extract_authors, extract_message_senders, extract_all_participants,
-    extract_thread_starter, thread_title, thread_waiting_on,
+import subprocess
+import sys
+
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+from human_threads import (  # noqa: E402
+    extract_all_participants,
+    extract_authors,
+    extract_message_senders,
+    extract_thread_body,
+    extract_thread_starter,
+    parse_threads,
+    resolve_threads_path,
+    thread_title,
+    thread_waiting_on,
 )
 
-content = open(os.environ["HUMAN_PATH"]).read()
+filepath = resolve_threads_path(os.environ.get("usage_file", ""))
+
+if not os.path.isfile(filepath):
+    print(
+        f"No threads file found at {filepath} — see available templates: threads template",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+with open(filepath, encoding="utf-8") as f:
+    content = f.read()
 _, threads = parse_threads(content)
 
+
+def run_gum(*args, input_text=None):
+    try:
+        subprocess.run(["gum", *args], input=input_text, text=True, check=True)
+    except FileNotFoundError:
+        print("gum: command not found", file=sys.stderr)
+        sys.exit(127)
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc.returncode)
+
+
 if not threads:
-    print("NO_THREADS")
+    run_gum("style", "--faint", "No threads found")
 else:
     # Participants column encodes roles: + = started thread, * = last sender
-    print("\t".join(["Status", "Thread", "Participants", "Waiting on"]))
+    rows = [["Status", "Thread", "Participants", "Waiting on"]]
     for kind, lines in threads:
         title = thread_title(lines[0])
         body_lines = extract_thread_body(lines)
@@ -45,22 +67,35 @@ else:
                 suffix += "*"
             annotated.append(name + suffix)
 
-        status_map = {"info": "info", "warning": "attention", "note": "active", "success": "resolved"}
+        status_map = {
+            "info": "info",
+            "warning": "attention",
+            "note": "active",
+            "success": "resolved",
+        }
         status = status_map.get(kind, kind)
 
-        print("\t".join([
-            status,
-            title,
-            ", ".join(annotated) if annotated else "\u2014",
-            waiting,
-        ]))
-PYEOF
-)
+        rows.append(
+            [
+                status,
+                title,
+                ", ".join(annotated) if annotated else "—",
+                waiting,
+            ]
+        )
 
-if [ "$output" = "NO_THREADS" ]; then
-  gum style --faint "No threads found"
-else
-  echo "$output" | gum table --print --separator "	" --border rounded \
-    --border.foreground 240 --header.foreground 81
-  gum style --faint "  + started thread  * last sender"
-fi
+    table_input = "\n".join("\t".join(row) for row in rows) + "\n"
+    run_gum(
+        "table",
+        "--print",
+        "--separator",
+        "\t",
+        "--border",
+        "rounded",
+        "--border.foreground",
+        "240",
+        "--header.foreground",
+        "81",
+        input_text=table_input,
+    )
+    run_gum("style", "--faint", "  + started thread  * last sender")

--- a/.mise/tasks/status
+++ b/.mise/tasks/status
@@ -1,23 +1,30 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 #MISE description="Quick summary of thread counts by status"
-#USAGE flag "--file <file>" help="Path to threads file"
-set -euo pipefail
+#USAGE flag "--file <file>" default="" help="Path to threads file"
 
-THREADS_PATH=$("$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "${usage_file:-}")
-
-if [ ! -f "$THREADS_PATH" ]; then
-  echo "No threads file found at $THREADS_PATH — see available templates: threads template" >&2
-  exit 1
-fi
-
-HUMAN_PATH="$THREADS_PATH" PYTHONPATH="$MISE_CONFIG_ROOT/lib" python3 << 'PYEOF'
 import os
-from human_threads import (
-    parse_threads, extract_thread_body,
-    extract_message_senders, thread_waiting_on,
+import sys
+
+sys.path.insert(0, os.environ["MISE_CONFIG_ROOT"] + "/lib")
+from human_threads import (  # noqa: E402
+    extract_message_senders,
+    extract_thread_body,
+    parse_threads,
+    resolve_threads_path,
+    thread_waiting_on,
 )
 
-content = open(os.environ["HUMAN_PATH"]).read()
+filepath = resolve_threads_path(os.environ.get("usage_file", ""))
+
+if not os.path.isfile(filepath):
+    print(
+        f"No threads file found at {filepath} — see available templates: threads template",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+with open(filepath, encoding="utf-8") as f:
+    content = f.read()
 _, threads = parse_threads(content)
 
 counts = {"agent": 0, "or": 0, "resolved": 0, "unknown": 0}
@@ -52,4 +59,3 @@ if counts["unknown"] > 0:
 
 total = sum(counts.values())
 print(f"{total} threads: {', '.join(parts)}")
-PYEOF

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 Parse, format, and archive [Obsidian-style callout](https://help.obsidian.md/callouts) threads.
 The async communication layer for humans and agents.
 
-![lang: bash + python](https://img.shields.io/badge/lang-bash%20%2B%20python-4EAA25?style=flat&logo=gnubash&logoColor=white)
-[![tests: 54 passing](https://img.shields.io/badge/tests-54%20passing-brightgreen?style=flat)](test/)
+![lang: python + bash](https://img.shields.io/badge/lang-python%20%2B%20bash-3776AB?style=flat&logo=python&logoColor=white)
+[![tests: 58 passing](https://img.shields.io/badge/tests-58%20passing-brightgreen?style=flat)](test/)
 ![commands: 5](https://img.shields.io/badge/commands-5-blue?style=flat)
 ![license: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat)
 
@@ -158,7 +158,7 @@ cd threads && mise trust && mise install
 mise run test
 ```
 
-**54 tests** across 6 suites. The parser is 244 lines of Python in `lib/human_threads.py`. Tasks are bash scripts that call into the parser for the heavy lifting. Templates use [farts](https://github.com/KnickKnackLabs/farts) for frontmatter.
+**58 tests** across 6 suites. The parser is 255 lines of Python in `lib/human_threads.py`. Core commands are Python mise file tasks that call into the shared parser; shell remains for small wrappers and tests. Templates use [farts](https://github.com/KnickKnackLabs/farts) for frontmatter.
 
 <details>
 <summary><b>Project structure</b></summary>
@@ -176,7 +176,7 @@ threads/
 ├── templates/
 │   └── *.md               # 1 template(s) with frontmatter metadata
 └── test/
-    └── *.bats             # 54 tests
+    └── *.bats             # 58 tests
 ```
 
 </details>

--- a/README.tsx
+++ b/README.tsx
@@ -56,7 +56,7 @@ const readme = (
       </Paragraph>
 
       <Badges>
-        <Badge label="lang" value="bash + python" color="4EAA25" logo="gnubash" logoColor="white" />
+        <Badge label="lang" value="python + bash" color="3776AB" logo="python" logoColor="white" />
         <Badge label="tests" value={`${testCount} passing`} color="brightgreen" href="test/" />
         <Badge label="commands" value={`${taskCount}`} color="blue" />
         <Badge label="license" value="MIT" color="blue" />
@@ -259,7 +259,7 @@ const readme = (
         <Bold>{`${testCount} tests`}</Bold>
         {` across ${testFiles.length} suites. The parser is ${parserLines} lines of Python in `}
         <Code>lib/human_threads.py</Code>
-        {". Tasks are bash scripts that call into the parser for the heavy lifting. Templates use "}
+        {". Core commands are Python mise file tasks that call into the shared parser; shell remains for small wrappers and tests. Templates use "}
         <Link href="https://github.com/KnickKnackLabs/farts">farts</Link>
         {" for frontmatter."}
       </Paragraph>

--- a/lib/human_threads.py
+++ b/lib/human_threads.py
@@ -7,6 +7,32 @@ from HUMAN.md files.
 import os
 import re
 
+
+def resolve_threads_path(file_arg=None):
+    """Resolve the target threads file path.
+
+    Resolution order:
+    1. Explicit file argument (from --file)
+    2. THREADS_FILE environment variable
+    3. HUMAN.md in the caller directory
+
+    Relative paths resolve against THREADS_CALLER_PWD. CALLER_PWD remains as
+    a legacy fallback while older shims/migration tests still exercise it.
+    """
+    file_arg = file_arg or os.environ.get("THREADS_FILE", "")
+    caller_dir = (
+        os.environ.get("THREADS_CALLER_PWD")
+        or os.environ.get("CALLER_PWD")
+        or os.getcwd()
+    )
+
+    if not file_arg:
+        return os.path.join(caller_dir, "HUMAN.md")
+    if not os.path.isabs(file_arg):
+        return os.path.join(caller_dir, file_arg)
+    return file_arg
+
+
 CALLOUT_OPENER = re.compile(r"^> \[!(info|note|warning|success)\][+-]?\s*")
 # Matches [Name] or **[Name]** or **[Name1 → Name2]** etc.
 # Uses greedy match and includes digits for names like x1f9, k7r2.

--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,6 @@ shiv = "https://github.com/KnickKnackLabs/vfox-shiv"
 [tools]
 bats = "1.13.0"
 gum = "latest"
-python = "3"
 "shiv:farts" = "v0.1.0"
 "shiv:readme" = "v0.1.0"
 usage = "latest"

--- a/test/archive.bats
+++ b/test/archive.bats
@@ -33,6 +33,19 @@ setup() {
   grep -q "Archived" "$ARCHIVE_PATH"
 }
 
+@test "archive: non-md files append .archive.md" {
+  THREADS_PATH="$TEST_DIR/THREADS.txt"
+  ARCHIVE_PATH="$TEST_DIR/THREADS.txt.archive.md"
+  export THREADS_PATH ARCHIVE_PATH
+  write_threads "$THREAD_SUCCESS"
+
+  run threads archive --file "$THREADS_PATH"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"THREADS.txt.archive.md"* ]]
+  [ -f "$ARCHIVE_PATH" ]
+  grep -q "Done thing" "$ARCHIVE_PATH"
+}
+
 @test "archive: appends to existing archive" {
   write_threads "$THREAD_SUCCESS"
   threads archive --file "$THREADS_PATH"

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -3,14 +3,16 @@
 # Provides test isolation via temporary directories and a threads()
 # wrapper that calls tasks through mise.
 
-if [ -z "${MISE_CONFIG_ROOT:-}" ]; then
-  echo "MISE_CONFIG_ROOT not set — run tests via: mise run test" >&2
-  exit 1
+if [ -z "${REPO_DIR:-}" ]; then
+  REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export REPO_DIR
+  eval "$(cd "$REPO_DIR" && mise env)"
 fi
 
 # Call threads tasks through mise — the only layer between tests and mise.
 threads() {
-  (cd "$MISE_CONFIG_ROOT" && mise run -q "$@")
+  local caller_pwd="${THREADS_CALLER_PWD:-$PWD}"
+  (cd "$REPO_DIR" && THREADS_CALLER_PWD="$caller_pwd" mise run -q "$@")
 }
 export -f threads
 

--- a/test/parser.bats
+++ b/test/parser.bats
@@ -8,31 +8,31 @@ setup() {
 # --- _resolve-file ---
 
 @test "_resolve-file: absolute path passes through" {
-  run bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "/tmp/absolute/HUMAN.md"
+  run bash "$REPO_DIR/.mise/tasks/_resolve-file" "/tmp/absolute/HUMAN.md"
   [ "$status" -eq 0 ]
   [ "$output" = "/tmp/absolute/HUMAN.md" ]
 }
 
 @test "_resolve-file: relative path resolves against THREADS_CALLER_PWD" {
-  run env THREADS_CALLER_PWD="/tmp/caller" bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "notes/BULLETIN.md"
+  run env THREADS_CALLER_PWD="/tmp/caller" bash "$REPO_DIR/.mise/tasks/_resolve-file" "notes/BULLETIN.md"
   [ "$status" -eq 0 ]
   [ "$output" = "/tmp/caller/notes/BULLETIN.md" ]
 }
 
 @test "_resolve-file: no arg defaults to THREADS_CALLER_PWD/HUMAN.md" {
-  run env THREADS_CALLER_PWD="/tmp/caller" THREADS_FILE= bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file"
+  run env THREADS_CALLER_PWD="/tmp/caller" THREADS_FILE= bash "$REPO_DIR/.mise/tasks/_resolve-file"
   [ "$status" -eq 0 ]
   [ "$output" = "/tmp/caller/HUMAN.md" ]
 }
 
 @test "_resolve-file: THREADS_FILE env is also CWD-relative" {
-  run env THREADS_CALLER_PWD="/tmp/caller" THREADS_FILE="notes/B.md" bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file"
+  run env THREADS_CALLER_PWD="/tmp/caller" THREADS_FILE="notes/B.md" bash "$REPO_DIR/.mise/tasks/_resolve-file"
   [ "$status" -eq 0 ]
   [ "$output" = "/tmp/caller/notes/B.md" ]
 }
 
 @test "_resolve-file: legacy CALLER_PWD fallback still works during migration" {
-  run env CALLER_PWD="/tmp/legacy" bash "$MISE_CONFIG_ROOT/.mise/tasks/_resolve-file" "notes/BULLETIN.md"
+  run env CALLER_PWD="/tmp/legacy" bash "$REPO_DIR/.mise/tasks/_resolve-file" "notes/BULLETIN.md"
   [ "$status" -eq 0 ]
   [ "$output" = "/tmp/legacy/notes/BULLETIN.md" ]
 }
@@ -41,7 +41,7 @@ setup() {
 
 @test "parser: extracts note thread" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import parse_threads
 _, threads = parse_threads('\n> [!note]- Title\n> Content\n')
 assert len(threads) == 1
@@ -52,7 +52,7 @@ assert threads[0][0] == 'note'
 
 @test "parser: extracts warning thread" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import parse_threads
 _, threads = parse_threads('\n> [!warning]- Title 👈\n> Content\n')
 assert len(threads) == 1
@@ -63,7 +63,7 @@ assert threads[0][0] == 'warning'
 
 @test "parser: extracts success thread" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import parse_threads
 _, threads = parse_threads('\n> [!success]- Title\n> Content\n')
 assert len(threads) == 1
@@ -74,7 +74,7 @@ assert threads[0][0] == 'success'
 
 @test "parser: handles multiple threads" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import parse_threads
 body = '''
 > [!note]- First
@@ -95,7 +95,7 @@ assert [t[0] for t in threads] == ['note', 'warning', 'success']
 
 @test "parser: preserves multi-paragraph content" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import parse_threads
 body = '''
 > [!note]- Multi
@@ -120,7 +120,7 @@ assert any('Para two' in l for l in lines)
 
 @test "parser: extracts authors from body" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import extract_authors
 lines = ['**[Or]** Hello.', '', '---', '', '**[junior]** Reply.']
 authors = extract_authors(lines)
@@ -131,7 +131,7 @@ assert authors == ['Or', 'junior'], f'got: {authors}'
 
 @test "parser: arrow chain yields last name as author" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import extract_authors
 lines = ['**[Or → Zeke]** Rewritten message.']
 authors = extract_authors(lines)
@@ -142,7 +142,7 @@ assert authors == ['Zeke'], f'got: {authors}'
 
 @test "parser: message senders yields first name in chain" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import extract_message_senders
 lines = ['**[Or → Zeke]** Rewritten message.']
 senders = extract_message_senders(lines)
@@ -155,7 +155,7 @@ assert senders == ['Or'], f'got: {senders}'
 
 @test "parser: human last sender means waiting on agent" {
   run python3 -c "
-import sys, os; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys, os; sys.path.insert(0, '$REPO_DIR/lib')
 os.environ['THREADS_HUMAN'] = 'Or'
 from human_threads import thread_waiting_on
 assert thread_waiting_on('note', ['Or']) == 'agent'
@@ -165,7 +165,7 @@ assert thread_waiting_on('note', ['Or']) == 'agent'
 
 @test "parser: agent last sender means waiting on human" {
   run python3 -c "
-import sys, os; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys, os; sys.path.insert(0, '$REPO_DIR/lib')
 os.environ['THREADS_HUMAN'] = 'Or'
 from human_threads import thread_waiting_on
 assert thread_waiting_on('note', ['Or', 'junior']) == 'Or'
@@ -175,7 +175,7 @@ assert thread_waiting_on('note', ['Or', 'junior']) == 'Or'
 
 @test "parser: success thread is resolved" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import thread_waiting_on
 assert thread_waiting_on('success', ['Or']) == 'resolved'
 "
@@ -184,7 +184,7 @@ assert thread_waiting_on('success', ['Or']) == 'resolved'
 
 @test "parser: no authors returns dash" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import thread_waiting_on
 assert thread_waiting_on('note', []) == '—'
 "
@@ -193,7 +193,7 @@ assert thread_waiting_on('note', []) == '—'
 
 @test "parser: no human configured returns dash for all active threads" {
   run python3 -c "
-import sys, os; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys, os; sys.path.insert(0, '$REPO_DIR/lib')
 os.environ.pop('THREADS_HUMAN', None)
 from human_threads import thread_waiting_on
 assert thread_waiting_on('note', ['Or', 'junior']) == '—'
@@ -205,7 +205,7 @@ assert thread_waiting_on('success', ['Or']) == 'resolved'
 
 @test "parser: explicit human_name argument overrides env" {
   run python3 -c "
-import sys, os; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys, os; sys.path.insert(0, '$REPO_DIR/lib')
 os.environ['THREADS_HUMAN'] = 'Or'
 from human_threads import thread_waiting_on
 assert thread_waiting_on('note', ['Alice'], human_name='Alice') == 'agent'
@@ -218,7 +218,7 @@ assert thread_waiting_on('note', ['junior'], human_name='Alice') == 'Alice'
 
 @test "parser: extracts title from opener" {
   run python3 -c "
-import sys; sys.path.insert(0, '$MISE_CONFIG_ROOT/lib')
+import sys; sys.path.insert(0, '$REPO_DIR/lib')
 from human_threads import thread_title
 assert thread_title('> [!warning]- Urgent thing 👈') == 'Urgent thing'
 assert thread_title('> [!note]- Simple title') == 'Simple title'

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+setup_suite() {
+  export REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+  # Load this repo's mise env even when tests are invoked directly via bats.
+  eval "$(cd "$REPO_DIR" && mise env)"
+}

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 setup_suite() {
-  export REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export REPO_DIR
 
   # Load this repo's mise env even when tests are invoked directly via bats.
   eval "$(cd "$REPO_DIR" && mise env)"


### PR DESCRIPTION
## Summary

- Convert `fmt`, `ls`, `status`, and `archive` from Bash wrappers with embedded Python heredocs into Python mise file tasks.
- Move shared threads-file path resolution into `lib/human_threads.py` and keep the legacy `CALLER_PWD` fallback covered by tests.
- Remove the unused `python = "3"` mise tool declaration so fresh `mise install` no longer trips the managed-Python install path.
- Update BATS setup to derive `REPO_DIR` from `$BATS_TEST_DIRNAME`, so direct `bats test/parser.bats` works in agent shells with stale inherited `$MISE_CONFIG_ROOT`.

Closes #23.

## Verification

- `bash -n .mise/tasks/_resolve-file .mise/tasks/template .mise/tasks/test/_default test/helpers.bash test/setup_suite.bash`
- `python3 -m py_compile lib/human_threads.py .mise/tasks/fmt .mise/tasks/ls .mise/tasks/status .mise/tasks/archive`
- `MISE_AUTO_INSTALL=0 mise run test` — 58/58
- `MISE_AUTO_INSTALL=0 bats test/parser.bats` — 20/20
- `MISE_AUTO_INSTALL=0 bats test/` — 58/58
- `MISE_AUTO_INSTALL=0 mise x shiv:readme@v0.1.0 -- readme build --check`
- `git diff --check`
- `mise install`
